### PR TITLE
Fix DynamoStreamReplicationIntegrationTest key attribute

### DIFF
--- a/tests/src/test/scala/com/scylladb/migrator/writers/DynamoStreamReplicationIntegrationTest.scala
+++ b/tests/src/test/scala/com/scylladb/migrator/writers/DynamoStreamReplicationIntegrationTest.scala
@@ -2,7 +2,7 @@ package com.scylladb.migrator.writers
 
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue => AttributeValueV1}
 import com.scylladb.migrator.AttributeValueUtils
-import com.scylladb.migrator.config.{DynamoDBEndpoint, TargetSettings}
+import com.scylladb.migrator.config.{AWSCredentials, DynamoDBEndpoint, TargetSettings}
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
@@ -33,25 +33,41 @@ class DynamoStreamReplicationIntegrationTest extends MigratorSuiteWithDynamoDBLo
   withTable(tableName).test("should correctly apply UPSERT and DELETE operations from a stream") { _ =>
     sourceDDb().putItem(
       PutItemRequest
-      .builder()
-      .tableName(tableName)
-      .item(Map("key" -> AttributeValue.builder.s("toDelete").build, "value" -> AttributeValue.builder.s("value1").build).asJava)
-      .item(Map("key" -> AttributeValue.builder.s("toUpdate").build, "value" -> AttributeValue.builder.s("value2").build).asJava)
-      .build()
-      )
+        .builder()
+        .tableName(tableName)
+        .item(
+          Map(
+            "id"    -> AttributeValue.builder.s("toDelete").build,
+            "value" -> AttributeValue.builder.s("value1").build
+          ).asJava
+        )
+        .build()
+    )
+    sourceDDb().putItem(
+      PutItemRequest
+        .builder()
+        .tableName(tableName)
+        .item(
+          Map(
+            "id"    -> AttributeValue.builder.s("toUpdate").build,
+            "value" -> AttributeValue.builder.s("value2").build
+          ).asJava
+        )
+        .build()
+    )
 
     val streamEvents = Seq(
       Some(Map(
-        "key" -> new AttributeValueV1().withS("toDelete"),
+        "id" -> new AttributeValueV1().withS("toDelete"),
         operationTypeColumn -> deleteOperation
       ).asJava),
       Some(Map(
-        "key" -> new AttributeValueV1().withS("toUpdate"),
+        "id" -> new AttributeValueV1().withS("toUpdate"),
         "value" -> new AttributeValueV1().withS("value2-updated"),
         operationTypeColumn -> putOperation
       ).asJava),
       Some(Map(
-        "key" -> new AttributeValueV1().withS("toInsert"),
+        "id" -> new AttributeValueV1().withS("toInsert"),
         "value" -> new AttributeValueV1().withS("value3"),
         operationTypeColumn -> putOperation
       ).asJava)
@@ -64,7 +80,7 @@ class DynamoStreamReplicationIntegrationTest extends MigratorSuiteWithDynamoDBLo
       table = tableName,
       region = Some("eu-central-1"),
       endpoint = Some(DynamoDBEndpoint("localhost", 8001)),
-      credentials = None,
+      credentials = Some(AWSCredentials("dummy", "dummy", None)),
       streamChanges = false,
       skipInitialSnapshotTransfer = Some(true),
       writeThroughput = None,
@@ -86,18 +102,18 @@ class DynamoStreamReplicationIntegrationTest extends MigratorSuiteWithDynamoDBLo
       DynamoDB
     )
 
-    val finalItems = scanAll(sourceDDb(), tableName).sortBy(m => m("key").s)
+    val finalItems = scanAll(sourceDDb(), tableName).sortBy(m => m("id").s)
 
     assertEquals(finalItems.size, 2)
 
-    assert(!finalItems.exists(_("key").s == "toDelete"))
+    assert(!finalItems.exists(_("id").s == "toDelete"))
 
 
-    val key2Item = finalItems.find(_("key").s == "toUpdate").get
+    val key2Item = finalItems.find(_("id").s == "toUpdate").get
     assertEquals(key2Item("value").s, "value2-updated")
 
 
-    val key3Item = finalItems.find(_("key").s == "toInsert").get
+    val key3Item = finalItems.find(_("id").s == "toInsert").get
     assertEquals(key3Item("value").s, "value3")
 
 


### PR DESCRIPTION
## Summary
- use correct `id` partition key when seeding DynamoDB
- adjust stream events and assertions accordingly
- supply dummy AWS credentials to prevent infinite DynamoDB credential retries

## Testing
- `./sbt "testOnly com.scylladb.migrator.writers.DynamoStreamReplicationIntegrationTest"` *(fails: not found type Signal, compilation failed)*
- `./sbt scalafmt`


------
https://chatgpt.com/codex/tasks/task_e_68a065c8b7c083259ed2acf776a1dccb